### PR TITLE
Set RenderDrawColor to black instead of white

### DIFF
--- a/src/platform/pret_sdl/sdl2.c
+++ b/src/platform/pret_sdl/sdl2.c
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
     }
 #endif
 
-    SDL_SetRenderDrawColor(sdlRenderer, 255, 255, 255, 255);
+    SDL_SetRenderDrawColor(sdlRenderer, 0, 0, 0, 255);
     SDL_RenderClear(sdlRenderer);
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
     SDL_RenderSetLogicalSize(sdlRenderer, DISPLAY_WIDTH, DISPLAY_HEIGHT);


### PR DESCRIPTION
This way fullscreen will not have white bars at the sides.