### PR TITLE
SA1 code revealed these are signed.

### DIFF
--- a/include/core.h
+++ b/include/core.h
@@ -293,7 +293,7 @@ extern FuncType_030053A0 gVBlankCallbacks[4];
 extern u8 gOamFreeIndex;
 extern u16 gUnknown_03001944;
 extern u8 gNumVBlankIntrs;
-extern u16 gUnknown_0300194C;
+extern s16 gUnknown_0300194C;
 
 extern Tilemap **gTilemapsRef;
 extern u8 gUnknown_03002280[4][4];
@@ -353,7 +353,7 @@ extern void *gUnknown_030022C0;
 extern s16 gMosaicReg;
 extern u8 gUnknown_030026F4;
 #endif
-extern u16 gUnknown_03002820;
+extern s16 gUnknown_03002820;
 extern u8 gUnknown_03002874;
 extern void *gHBlankCopyTarget;
 extern u8 gBackgroundsCopyQueueIndex;

--- a/src/core.c
+++ b/src/core.c
@@ -47,7 +47,7 @@ BgAffineReg gBgAffineRegs[NUM_AFFINE_BACKGROUNDS] ALIGNED(8) = {};
 void *gVramHeapStartAddr = NULL;
 u16 gUnknown_03001944 ALIGNED(4) = 0;
 u8 gNumVBlankIntrs ALIGNED(4) = 0;
-u16 gUnknown_0300194C ALIGNED(4) = 0;
+s16 gUnknown_0300194C ALIGNED(4) = 0;
 
 u32 gMultiSioStatusFlags = 0;
 bool8 gMultiSioEnabled = FALSE;
@@ -89,7 +89,7 @@ struct GraphicsData gVramGraphicsCopyQueueBuffer[32] = {};
 #endif
 struct GraphicsData *gVramGraphicsCopyQueue[] ALIGNED(16) = {};
 
-u16 gUnknown_03002820 = 0;
+s16 gUnknown_03002820 = 0;
 s16 gBgScrollRegs[][2] ALIGNED(16) = {};
 u16 gDispCnt = 0;
 u8 gKeysContinuedRepeatIntervals[10] ALIGNED(16) = {};


### PR DESCRIPTION
No idea what they are except for some x|y values that are very far apart in RAM for some reason.