### PR TITLE
Align Div/Mod with SA1

### DIFF
--- a/include/gba/syscall.h
+++ b/include/gba/syscall.h
@@ -60,10 +60,13 @@ s32 Mod(s32 num, s32 denom);
 s32 ModArm(s32 denom, s32 num);
 #else
 // New GCC doesn't like us calling a function 'Mod', so we'll just inline them all.
-#define Div(num, denom)    ({((denom) != 0) ? ((s32)(num) / (denom)) : 0;})
-#define Mod(num, denom)    ({((denom) != 0) ? ((s32)(num) % (denom)) : 0;})
-#define DivArm(denom, num) ({((denom) != 0) ? ((s32)(num) / (denom)) : 0;})
-#define ModArm(denom, num) ({((denom) != 0) ? ((s32)(num) % (denom)) : 0;})
+// Also it is VERY important to also cast 'denom' to s32 on 64bit architectures,
+// otherwise 'num' might be interpreted as a s64, without being properly cast as one,
+// leading to a signed s32 value getting divided like an unsigned one.
+#define Div(num, denom)    ({((denom) != 0) ? ((s32)(num) / (s32)(denom)) : 0;})
+#define Mod(num, denom)    ({((denom) != 0) ? ((s32)(num) % (s32)(denom)) : 0;})
+#define DivArm(denom, num) ({((denom) != 0) ? ((s32)(num) / (s32)(denom)) : 0;})
+#define ModArm(denom, num) ({((denom) != 0) ? ((s32)(num) % (s32)(denom)) : 0;})
 #endif
 
 void SoundBiasReset(void);


### PR DESCRIPTION
The denominator not getting cast to s32 led to `num` getting handled like an s64 value but with the upper 32bits cleared, so negative values weren't divided correctly.